### PR TITLE
3.14 Audio Cape DT fixes

### DIFF
--- a/arch/arm/boot/dts/am335x-bone-audio-revb.dtsi
+++ b/arch/arm/boot/dts/am335x-bone-audio-revb.dtsi
@@ -13,6 +13,9 @@
 	P9_20_pinmux {
 		mode = "i2c";
 	};
+
+	/* The following are disabled because the audio mode is set
+	   by <&mcasp0_pins_audio_revb>. */
 	P9_25_pinmux {
 		/* mcasp0_ahclkx, OUTPUT | MODE0, Codec MCLK */
 		status = "disabled";
@@ -28,6 +31,8 @@
 	P9_30_pinmux {
 		/* mcasp0_axr0, INPUT | MODE0, Codec DOUT */
 		status = "disabled";
+		/* TODO Add support in am335x-bone-common-pinmux.dtsi
+		 * for an "audio" mode. */
 	};
 	P9_31_pinmux {
 		/* mcasp0_aclkx, INPUT | MODE0, Codec BCLK */

--- a/arch/arm/boot/dts/am335x-bone-audio-revb.dtsi
+++ b/arch/arm/boot/dts/am335x-bone-audio-revb.dtsi
@@ -7,6 +7,12 @@
  */
 
 &ocp {
+	P9_19_pinmux {
+		mode = "i2c";
+	};
+	P9_20_pinmux {
+		mode = "i2c";
+	};
 	P9_25_pinmux {
 		/* mcasp0_ahclkx, OUTPUT | MODE0, Codec MCLK */
 		status = "disabled";

--- a/arch/arm/boot/dts/am335x-bone-audio-revb.dtsi
+++ b/arch/arm/boot/dts/am335x-bone-audio-revb.dtsi
@@ -73,7 +73,7 @@
 		ti,model = "DA830 EVM";
 		ti,audio-codec = <&tlv320aic3x>;
 		ti,mcasp-controller = <&mcasp0>;
-		ti,codec-clock-rate = <12000000>;
+		ti,codec-clock-rate = <24000000>;
 		ti,audio-routing =
 			"Headphone Jack",       "HPLOUT",
 			"Headphone Jack",       "HPROUT",


### PR DESCRIPTION
These patches are what it took for me to make the audio cape work on the
3.14 kernel on the BeagleBone Black.

Patch 1 makes it work.
Patch 2 makes it not play double-speed.
Patch 3 is some comments. Take or leave. It may help someone not
get tripped up in the future.

#2 is a bit strange. The 12MHz value worked for the 3.8 kernel with the DT
overlay, but not in the current 3.14 branch.  This may not be the best way
to fix the issue, but maybe it helps someone discover the real problem.  The
TI SDK 7.0.0.0 kernel requires the 24 MHz clock value as well.

These patches are against 1d0defeba9685e616b05f7340111ab84c47ad762 of
https://github.com/beagleboard/linux (branch 3.14).

Alan.
