### PR TITLE
Updated defines to fully work with BeagleBone

### DIFF
--- a/drivers/gpio/gpio-pca953x.c
+++ b/drivers/gpio/gpio-pca953x.c
@@ -24,6 +24,10 @@
 #include <linux/of_platform.h>
 #endif
 
+#define CONFIG_OF_GPIO		1
+#define CONFIG_GPIO_PCA953X_IRQ	1
+#define CONFIG_ARM		1
+
 #define PCA953X_INPUT		0
 #define PCA953X_OUTPUT		1
 #define PCA953X_INVERT		2


### PR DESCRIPTION
DTS EXAMPLE TESTED WITH PCA9555 3.8.13 branch

/dts-v1/;
/plugin/;

/ {
	compatible = "ti,beaglebone", "ti,beaglebone-black";

	/* identification */
	part-number = "BB-PCA9555-20";
	version = "00A0";
	
	/* state the resources this cape uses */
	exclusive-use =
	/* the pin header uses */
	"P8.8",	/* pca9555 irq: gpio2_3 */
	
	/* the hardware ip uses */
	"gpio2_3";
	
	fragment@0 {
		target = <&am33xx_pinmux>;
		__overlay__ {

			pca9555_irq_pin: pinmux_pca9555_irq_pin {
				pinctrl-single,pins = <
					0x094 0x37	/* gpmc_oen_ren.gpio2_3    INPUT | PULLUP | MODE7 */
				>;
			};
		};
	};

	fragment@1 {
		target = <&i2c2>;
		__overlay__ {
			#address-cells = <1>;
			#size-cells = <0>;

			pca9555: pca9555@20 {
				compatible = "nxp,pca9555";
				reg = <0x20>;
				pinctrl-0 = <&pca9555_irq_pin>;
				interrupt-parent = <&gpio3>;
				interrupts = <3 0x2>;
				irg-gpio = <&gpio3 3 2>;
				gpio-controller;
				#gpio-cells = <2>;
				interrupt-controller;
				#interrupt-cells = <2>;
				status = "okay";
			};
		};
	};
};