### PR TITLE
Modifications and drivers for CTAG face2|4 Multichannel Audio Card

### DIFF
--- a/arch/arm/boot/dts/Makefile
+++ b/arch/arm/boot/dts/Makefile
@@ -416,6 +416,7 @@ dtb-$(CONFIG_SOC_AM33XX) += \
 	am335x-base0033.dtb \
 	am335x-bone.dtb \
 	am335x-boneblack.dtb \
+	am335x-bonegreen-ctag-face.dtb \
 	am335x-bonegreen-overlay.dtb \
 	am335x-bonegreen-wireless.dtb \
 	am335x-bonegreen.dtb \

--- a/arch/arm/boot/dts/am335x-bonegreen-ctag-face.dts
+++ b/arch/arm/boot/dts/am335x-bonegreen-ctag-face.dts
@@ -1,7 +1,7 @@
 /*
- * Base device tree of BeagleBone Green with AD1938 AudioCard
+ * Base device tree for BeagleBone Green with CTAG face2|4 Audio Card
  *
- * Author:  Henrik Langer <henrik.langer@student.fh-kiel.de>
+ * Author:  Henrik Langer <henni19790@googlemail.com>
  *			based on
  				BeagleBone Black and BeagleBone Green device tree
  *

--- a/arch/arm/boot/dts/am335x-bonegreen-ctag-face.dts
+++ b/arch/arm/boot/dts/am335x-bonegreen-ctag-face.dts
@@ -1,0 +1,99 @@
+/*
+ * Base device tree of BeagleBone Green with AD1938 AudioCard
+ *
+ * Author:  Henrik Langer <henrik.langer@student.fh-kiel.de>
+ *			based on
+ 				BeagleBone Black and BeagleBone Green device tree
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+/dts-v1/;
+
+#include "am33xx.dtsi"
+#include "am335x-bone-common.dtsi"
+
+/ {
+	model = "TI AM335x BeagleBone Green AudioCard";
+	compatible = "ti,am335x-bone-green", "ti,am335x-bone-black", "ti,am335x-bone", "ti,am33xx";
+};
+
+&ldo3_reg {
+	regulator-min-microvolt = <1800000>;
+	regulator-max-microvolt = <1800000>;
+	regulator-always-on;
+};
+
+&mmc1 {
+	vmmc-supply = <&vmmcsd_fixed>;
+};
+
+&mmc2 {
+	vmmc-supply = <&vmmcsd_fixed>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&emmc_pins>;
+	bus-width = <8>;
+	status = "okay";
+};
+
+&sgx {
+	status = "okay";
+};
+
+&am33xx_pinmux {
+	mcasp0_pins: mcasp0_pins {
+		pinctrl-single,pins = <
+			0x1ac (PIN_INPUT_PULLDOWN | MUX_MODE0)	/* mcasp0_ahclkx */
+			0x19c (PIN_OUTPUT_PULLDOWN | MUX_MODE2) /* mcasp0_axr2 */
+			0x194 (PIN_INPUT_PULLDOWN | MUX_MODE0)	/* mcasp0_fsx */ 
+			0x190 (PIN_INPUT_PULLDOWN | MUX_MODE0)	/* mcasp0_aclkx */
+			0x1a4 (PIN_INPUT_PULLDOWN | MUX_MODE0)	/* mcasp0_fsr */
+			0x078 (PIN_INPUT_PULLDOWN | MUX_MODE6)	/* mcasp0_aclkr */
+			0x198 (PIN_INPUT_PULLDOWN | MUX_MODE0)	/* mcasp0_axr0 */
+			0x06c (PIN_OUTPUT_PULLDOWN | MUX_MODE7)	/* gpio1[27] (enable oscillator) */
+		>;
+	};
+
+	mcasp0_pins_sleep: mcasp0_pins_sleep {
+		pinctrl-single,pins = <
+			0x1ac (PIN_INPUT_PULLDOWN | MUX_MODE7)	/* mcasp0_ahclkx */
+			0x19c (PIN_INPUT_PULLDOWN | MUX_MODE7)	/* mcasp0_axr2 */
+			0x194 (PIN_INPUT_PULLDOWN | MUX_MODE7)	/* mcasp0_fsx */
+			0x190 (PIN_INPUT_PULLDOWN | MUX_MODE7)	/* mcasp0_aclkx */
+			0x1a4 (PIN_INPUT_PULLDOWN | MUX_MODE0)	/* mcasp0_fsr */
+			0x078 (PIN_INPUT_PULLDOWN | MUX_MODE6)	/* mcasp0_aclkr */
+			0x198 (PIN_INPUT_PULLDOWN | MUX_MODE7)	/* mcasp0_axr0 */
+			0x06c (PIN_INPUT_PULLDOWN | MUX_MODE7)	/* gpio1[27] */
+		>;
+	};
+};
+
+&mcasp0	{
+	pinctrl-names = "default", "sleep";
+	pinctrl-0 = <&mcasp0_pins>;
+	pinctrl-1 = <&mcasp0_pins_sleep>;
+	status = "okay";
+	op-mode = <0>;	/* MCASP_IIS_MODE */
+	tdm-slots = <2>;
+	serial-dir = <	/* 0: INACTIVE, 1: TX, 2: RX */
+			2 0 1 0
+		>;
+	tx-num-evt = <1>;
+	rx-num-evt = <1>;
+};
+
+/ {
+	clk_mcasp0_fixed: clk_mcasp0_fixed {
+	      #clock-cells = <0>;
+	      compatible = "fixed-clock";
+	      clock-frequency = <24576000>;
+	};
+
+	clk_mcasp0: clk_mcasp0 {
+	      #clock-cells = <0>;
+	      compatible = "gpio-gate-clock";
+	      clocks = <&clk_mcasp0_fixed>;
+	      enable-gpios = <&gpio1 27 0>; /* BeagleBone Black Clk enable on GPIO1_27 */
+	};
+};

--- a/sound/soc/codecs/Kconfig
+++ b/sound/soc/codecs/Kconfig
@@ -221,12 +221,16 @@ config SND_SOC_AD193X
 	tristate
 
 config SND_SOC_AD193X_SPI
-	tristate
+	tristate "Analog Devices AD193x CODEC (SPI)"
+	depends on SPI_MASTER
 	select SND_SOC_AD193X
+	select REGMAP_SPI
 
 config SND_SOC_AD193X_I2C
-	tristate
+	tristate "Analog Devices AD193x CODEC (I2C)"
+	depends on I2C
 	select SND_SOC_AD193X
+	select REGMAP_I2C
 
 config SND_SOC_AD1980
 	select REGMAP_AC97

--- a/sound/soc/codecs/ad193x-spi.c
+++ b/sound/soc/codecs/ad193x-spi.c
@@ -33,13 +33,29 @@ static int ad193x_spi_remove(struct spi_device *spi)
 	return 0;
 }
 
+static const struct spi_device_id ad193x_spi_id[] = {
+	{ "ad1938", },
+	{ "ad1939", },
+	{ },
+};
+MODULE_DEVICE_TABLE(spi, ad193x_spi_id);
+
+static const struct of_device_id ad193x_of_match[] = {
+	{ .compatible = "analog,ad1938", },
+	{ .compatible = "analog,ad1939", },
+	{ }
+};
+MODULE_DEVICE_TABLE(of, ad193x_of_match);
+
 static struct spi_driver ad193x_spi_driver = {
 	.driver = {
 		.name	= "ad193x",
 		.owner	= THIS_MODULE,
+		.of_match_table = ad193x_of_match,
 	},
 	.probe		= ad193x_spi_probe,
 	.remove		= ad193x_spi_remove,
+	.id_table	= ad193x_spi_id
 };
 module_spi_driver(ad193x_spi_driver);
 

--- a/sound/soc/codecs/ad193x.c
+++ b/sound/soc/codecs/ad193x.c
@@ -247,7 +247,7 @@ static int ad193x_hw_params(struct snd_pcm_substream *substream,
 		struct snd_pcm_hw_params *params,
 		struct snd_soc_dai *dai)
 {
-	int word_len = 0, master_rate = 0;
+	int word_len = 0, master_rate = 0, sample_rate = 0;
 	struct snd_soc_codec *codec = dai->codec;
 	struct ad193x_priv *ad193x = snd_soc_codec_get_drvdata(codec);
 
@@ -265,6 +265,22 @@ static int ad193x_hw_params(struct snd_pcm_substream *substream,
 		break;
 	}
 
+	/* sample rate */
+	switch(params_rate(params)){
+	case 48000:
+		sample_rate = 0;
+		break;
+	case 96000:
+		sample_rate = 1;
+		break;
+	case 192000:
+		sample_rate = 2;
+		break;
+	default:
+		sample_rate = 0; //48 kHz
+		break;
+	}
+
 	switch (ad193x->sysclk) {
 	case 12288000:
 		master_rate = AD193X_PLL_INPUT_256;
@@ -279,6 +295,12 @@ static int ad193x_hw_params(struct snd_pcm_substream *substream,
 		master_rate = AD193X_PLL_INPUT_768;
 		break;
 	}
+
+	regmap_update_bits(ad193x->regmap, AD193X_DAC_CTRL0, 
+				0x06, sample_rate << 1);
+
+	regmap_update_bits(ad193x->regmap, AD193X_ADC_CTRL0,
+				0xC0, sample_rate << 6);
 
 	regmap_update_bits(ad193x->regmap, AD193X_PLL_CLK_CTRL0,
 			    AD193X_PLL_INPUT_MASK, master_rate);
@@ -308,7 +330,7 @@ static struct snd_soc_dai_driver ad193x_dai = {
 		.stream_name = "Playback",
 		.channels_min = 2,
 		.channels_max = 8,
-		.rates = SNDRV_PCM_RATE_48000,
+		.rates = SNDRV_PCM_RATE_48000 | SNDRV_PCM_RATE_96000 | SNDRV_PCM_RATE_192000,
 		.formats = SNDRV_PCM_FMTBIT_S32_LE | SNDRV_PCM_FMTBIT_S16_LE |
 			SNDRV_PCM_FMTBIT_S20_3LE | SNDRV_PCM_FMTBIT_S24_LE,
 	},
@@ -316,7 +338,7 @@ static struct snd_soc_dai_driver ad193x_dai = {
 		.stream_name = "Capture",
 		.channels_min = 2,
 		.channels_max = 4,
-		.rates = SNDRV_PCM_RATE_48000,
+		.rates = SNDRV_PCM_RATE_48000 | SNDRV_PCM_RATE_96000 | SNDRV_PCM_RATE_192000,
 		.formats = SNDRV_PCM_FMTBIT_S32_LE | SNDRV_PCM_FMTBIT_S16_LE |
 			SNDRV_PCM_FMTBIT_S20_3LE | SNDRV_PCM_FMTBIT_S24_LE,
 	},
@@ -327,21 +349,26 @@ static int ad193x_codec_probe(struct snd_soc_codec *codec)
 {
 	struct ad193x_priv *ad193x = snd_soc_codec_get_drvdata(codec);
 
-	/* default setting for ad193x */
-
-	/* unmute dac channels */
+	/* modified settings for ad193x */
+	
+	// pll input 256: mclki/xi, xtal oscillator enabled 
+	regmap_write(ad193x->regmap, AD193X_PLL_CLK_CTRL0, 0x80);
+	// adc / dac clock source: mclk
+	regmap_write(ad193x->regmap, AD193X_PLL_CLK_CTRL1, 0x00);
+	// dac in tdm mode, sdata delay: 1, 48kHz sample rate
+	regmap_write(ad193x->regmap, AD193X_DAC_CTRL0, AD193X_DAC_SERFMT_TDM);
+	// DAC bclk and lcr slave, 256 bclk per frame
+	regmap_write(ad193x->regmap, AD193X_DAC_CTRL1, 0x04);
+	// word width: 16, de-emphasis: 48kHz, powedown dac
+	regmap_write(ad193x->regmap, AD193X_DAC_CTRL2, 0x1A); 
+	// unmute dac channels
 	regmap_write(ad193x->regmap, AD193X_DAC_CHNL_MUTE, 0x0);
-	/* de-emphasis: 48kHz, powedown dac */
-	regmap_write(ad193x->regmap, AD193X_DAC_CTRL2, 0x1A);
-	/* dac in tdm mode */
-	regmap_write(ad193x->regmap, AD193X_DAC_CTRL0, 0x40);
-	/* high-pass filter enable */
-	regmap_write(ad193x->regmap, AD193X_ADC_CTRL0, 0x3);
-	/* sata delay=1, adc aux mode */
-	regmap_write(ad193x->regmap, AD193X_ADC_CTRL1, 0x43);
-	/* pll input: mclki/xi */
-	regmap_write(ad193x->regmap, AD193X_PLL_CLK_CTRL0, 0x99); /* mclk=24.576Mhz: 0x9D; mclk=12.288Mhz: 0x99 */
-	regmap_write(ad193x->regmap, AD193X_PLL_CLK_CTRL1, 0x04);
+	// high-pass filter enable
+	regmap_write(ad193x->regmap, AD193X_ADC_CTRL0, 0x02);
+	// sdata delay=1, adc tdm mode, word width: 16
+	regmap_write(ad193x->regmap, AD193X_ADC_CTRL1, AD193X_ADC_SERFMT_TDM | 0x03);
+	// 256 bclks per frame
+	regmap_write(ad193x->regmap, AD193X_ADC_CTRL2, 0x20); //0x02
 
 	return 0;
 }

--- a/sound/soc/davinci/Kconfig
+++ b/sound/soc/davinci/Kconfig
@@ -101,7 +101,7 @@ config  SND_DA850_SOC_EVM
 	  DA850/OMAP-L138 EVM
 
 config	SND_DAVINCI_SOC_CTAG_FACE_2_4
-	tristate "SoC Audio Support for CTAG face-2-4 (AD1938)"
+	tristate "SoC Audio Support for CTAG face-2-4 Audio Card (AD1938)"
 	depends on SND_DAVINCI_SOC_MCASP
 	select SND_SOC_AD193X_SPI
 	help

--- a/sound/soc/davinci/Kconfig
+++ b/sound/soc/davinci/Kconfig
@@ -100,3 +100,9 @@ config  SND_DA850_SOC_EVM
 	  Say Y if you want to add support for SoC audio on TI
 	  DA850/OMAP-L138 EVM
 
+config	SND_DAVINCI_SOC_CTAG_FACE_2_4
+	tristate "SoC Audio Support for CTAG face-2-4 (AD1938)"
+	depends on SND_DAVINCI_SOC_MCASP
+	select SND_SOC_AD193X_SPI
+	help
+	  Say Y if you want to add support for SoC audio on CTAG face-2-4.

--- a/sound/soc/davinci/Makefile
+++ b/sound/soc/davinci/Makefile
@@ -3,11 +3,13 @@ snd-soc-edma-objs := edma-pcm.o
 snd-soc-davinci-i2s-objs := davinci-i2s.o
 snd-soc-davinci-mcasp-objs:= davinci-mcasp.o
 snd-soc-davinci-vcif-objs:= davinci-vcif.o
+snd-soc-davinci-ctag-face-2-4-objs := davinci-ctag-face-2-4.o
 
 obj-$(CONFIG_SND_EDMA_SOC) += snd-soc-edma.o
 obj-$(CONFIG_SND_DAVINCI_SOC_I2S) += snd-soc-davinci-i2s.o
 obj-$(CONFIG_SND_DAVINCI_SOC_MCASP) += snd-soc-davinci-mcasp.o
 obj-$(CONFIG_SND_DAVINCI_SOC_VCIF) += snd-soc-davinci-vcif.o
+obj-$(CONFIG_SND_DAVINCI_SOC_CTAG_FACE_2_4) += snd-soc-davinci-ctag-face-2-4.o
 
 # Generic DAVINCI/AM33xx Machine Support
 snd-soc-evm-objs := davinci-evm.o

--- a/sound/soc/davinci/davinci-ctag-face-2-4.c
+++ b/sound/soc/davinci/davinci-ctag-face-2-4.c
@@ -1,7 +1,7 @@
 /*
- * ASoC machine driver for Davinci platform (BBG) and ad1938 audio codec.
+ * ASoC machine driver for CTAG face2|4 Audio Card
  *
- * Author:	Henrik Langer <henrik.langer@student.fh-kiel.de>
+ * Author:	Henrik Langer <henni19790@googlemail.com>
  *        	based on 
  * 				ASoC driver for TI DAVINCI EVM platform by 
  *				Vladimir Barinov <vbarinov@embeddedalley.com>

--- a/sound/soc/davinci/davinci-ctag-face-2-4.c
+++ b/sound/soc/davinci/davinci-ctag-face-2-4.c
@@ -1,0 +1,336 @@
+/*
+ * ASoC machine driver for Davinci platform (BBG) and ad1938 audio codec.
+ *
+ * Author:	Henrik Langer <henrik.langer@student.fh-kiel.de>
+ *        	based on 
+ * 				ASoC driver for TI DAVINCI EVM platform by 
+ *				Vladimir Barinov <vbarinov@embeddedalley.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ */
+
+#include <linux/module.h>
+#include <linux/moduleparam.h>
+#include <linux/timer.h>
+#include <linux/interrupt.h>
+#include <linux/platform_device.h>
+#include <linux/of_platform.h>
+#include <linux/clk.h>
+#include <sound/core.h>
+#include <sound/pcm.h>
+#include <sound/pcm_params.h>
+#include <sound/soc.h>
+#include <asm/dma.h>
+#include <asm/mach-types.h>
+
+#include "../codecs/ad193x.h"
+
+struct snd_soc_card_drvdata_davinci {
+	struct clk *mclk;
+	unsigned sysclk;
+	unsigned codec_clock;
+};
+
+/*
+	Define Dynamic Audio Power Management (DAPM) widgets
+*/
+static const struct snd_soc_dapm_widget ad193x_dapm_widgets[] = {
+	SND_SOC_DAPM_LINE("Line Out", NULL),
+	SND_SOC_DAPM_LINE("Line In", NULL),
+};
+
+static const struct snd_soc_dapm_route audio_map[] = {
+	{"Line Out", NULL, "DAC1OUT"},
+	{"Line Out", NULL, "DAC2OUT"},
+	{"Line Out", NULL, "DAC3OUT"},
+	{"Line Out", NULL, "DAC4OUT"},
+	{"ADC1IN", NULL, "Line In"},
+	{"ADC2IN", NULL, "Line In"},
+};
+
+/* 
+	Sound card init 
+*/
+static int snd_davinci_audiocard_init(struct snd_soc_pcm_runtime *rtd)
+{
+	struct snd_soc_card *card = rtd->card;
+	struct device_node *np = card->dev->of_node;
+	struct snd_soc_dai *cpu_dai = rtd->cpu_dai;
+	struct snd_soc_dai *codec_dai = rtd->codec_dai;
+	int ret;
+	unsigned int tdm_mask = 0x00;
+	u32 tdm_slots;
+
+	/* 
+		Add davinci-evm specific DAPM widgets
+	*/
+	snd_soc_dapm_new_controls(&card->dapm, ad193x_dapm_widgets,
+				  ARRAY_SIZE(ad193x_dapm_widgets));
+
+	/*
+		Get audio routing from device tree or use built-in routing
+	*/
+	if (np) {
+		dev_dbg(card->dev, "Using configuration from dt overlay.\n");
+		ret = snd_soc_of_parse_audio_routing(card, "audio-routing");
+		if (ret)
+			return ret;
+		ret = of_property_read_u32(np, "audiocard-tdm-slots", &tdm_slots);
+		if (tdm_slots > 8 || tdm_slots < 2 || ret){
+			dev_dbg(card->dev, "Couldn't get device tree property for tdm slots. Using default (=2).\n");
+			tdm_slots = 2;
+			tdm_mask = 0x03; // lsb for slot 0, ...
+		} else {
+			tdm_mask = 0xFF;
+			tdm_mask = tdm_mask >> (8 - tdm_slots);
+		}
+	} else {
+		dev_dbg(card->dev, "Use builtin audio routing.\n");
+		/* Set up davinci specific audio path audio_map */
+		snd_soc_dapm_add_routes(&card->dapm, audio_map,
+					ARRAY_SIZE(audio_map));
+	}
+
+	/*
+		Configure TDM mode of CPU and audio codec interface
+		(ad193x codec driver ignores TX / RX mask and width)
+	*/
+	ret = snd_soc_dai_set_tdm_slot(codec_dai, tdm_mask, tdm_mask, tdm_slots, 32);
+	if (ret < 0){
+		dev_err(codec_dai->dev, "Unable to set AD193x TDM slots.\n");
+		return ret;
+	}
+	ret = snd_soc_dai_set_tdm_slot(cpu_dai, tdm_mask, tdm_mask, tdm_slots, 32);
+	if (ret < 0){
+		dev_err(codec_dai->dev, "Unable to set McASP TDM slots.\n");
+		return ret;
+	}
+
+	return 0;
+}
+
+/* 
+	Set hw parameters 
+*/
+static int snd_davinci_audiocard_hw_params(struct snd_pcm_substream *substream,
+				       struct snd_pcm_hw_params *params)
+{
+	int ret = 0;
+	struct snd_soc_pcm_runtime *rtd = substream->private_data;
+	struct snd_soc_dai *cpu_dai = rtd->cpu_dai;
+	struct snd_soc_dai *codec_dai = rtd->codec_dai;
+	struct snd_soc_codec *codec = rtd->codec;
+	struct snd_soc_card *soc_card = rtd->card;
+	unsigned cpu_clock = ((struct snd_soc_card_drvdata_davinci *) 
+		snd_soc_card_get_drvdata(soc_card))->sysclk;
+	unsigned codec_clock = ((struct snd_soc_card_drvdata_davinci *) 
+		snd_soc_card_get_drvdata(soc_card))->codec_clock;
+
+	/*
+		Set master clock of CPU and audio codec interface
+		(ad193x codec driver ignores clock ID and direction)
+	*/
+	ret = snd_soc_dai_set_sysclk(codec_dai, 0, codec_clock, SND_SOC_CLOCK_IN);
+	if (ret < 0){
+		dev_err(codec->dev, "Unable to set AD193x system clock: %d.\n", ret);
+		return ret;
+	}
+	dev_dbg(cpu_dai->dev, "Set codec DAI clock rate to %d.\n", codec_clock);
+
+	ret = snd_soc_dai_set_sysclk(cpu_dai, 0, cpu_clock, SND_SOC_CLOCK_OUT);
+	if (ret < 0){
+		dev_err(cpu_dai->dev, "Unable to set cpu dai sysclk: %d.\n", ret);
+		return ret;
+	}
+	dev_dbg(cpu_dai->dev, "Set CPU DAI clock rate to %d.\n", cpu_clock);
+
+	return 0;
+}
+
+/* 
+	Startup 
+*/
+static int snd_davinci_audiocard_startup(struct snd_pcm_substream *substream) {
+	struct snd_soc_pcm_runtime *rtd = substream->private_data;
+	struct snd_soc_card *soc_card = rtd->card;
+	struct snd_soc_card_drvdata_davinci *drvdata = snd_soc_card_get_drvdata(soc_card);
+
+	if (drvdata->mclk)
+		return clk_prepare_enable(drvdata->mclk);
+
+	return 0;
+}
+
+/* 
+	Shutdown 
+*/
+static void snd_davinci_audiocard_shutdown(struct snd_pcm_substream *substream) {
+	struct snd_soc_pcm_runtime *rtd = substream->private_data;
+	struct snd_soc_card *soc_card = rtd->card;
+	struct snd_soc_card_drvdata_davinci *drvdata = snd_soc_card_get_drvdata(soc_card);
+
+	if (drvdata->mclk)
+		clk_disable_unprepare(drvdata->mclk);
+}
+
+/* 
+	Machine stream operations 
+*/
+static struct snd_soc_ops snd_davinci_audiocard_ops = {
+	.hw_params = snd_davinci_audiocard_hw_params,
+	.startup = snd_davinci_audiocard_startup,
+	.shutdown = snd_davinci_audiocard_shutdown,
+};
+
+/* 
+	Interface setup 
+	(rxclk and txclk are configured asynchronous in i2s mode (see mcasp platform driver))
+*/
+#define AUDIOCARD_AD193X_DAIFMT ( SND_SOC_DAIFMT_I2S | SND_SOC_DAIFMT_NB_IF | SND_SOC_DAIFMT_CBM_CFM )
+/* 
+	Struct ist just a placeholder. Device tree will add cpu and codec nodes here
+*/
+static struct snd_soc_dai_link snd_davinci_audiocard_dai = {
+	.name = "CTAG face-2-4",
+	.stream_name = "TDM",
+	.codec_dai_name ="ad193x-hifi",
+	.dai_fmt = AUDIOCARD_AD193X_DAIFMT,
+	.ops = &snd_davinci_audiocard_ops,
+	.init = snd_davinci_audiocard_init,
+};
+
+/*
+	Export device tree identifiers
+*/
+static const struct of_device_id snd_davinci_audiocard_dt_ids[] = {
+	{
+		.compatible = "ctag,face-2-4",
+		.data = &snd_davinci_audiocard_dai,
+	},
+	{ /* sentinel */ }
+};
+MODULE_DEVICE_TABLE(of, snd_davinci_audiocard_dt_ids);
+
+/* 
+	Audio machine driver 
+*/
+static struct snd_soc_card snd_davinci_audiocard = {
+	.owner = THIS_MODULE,
+	.num_links = 1,
+};
+
+/* 
+	Sound card probe
+*/
+static int snd_davinci_audiocard_probe(struct platform_device *pdev)
+{
+	struct device_node *np = pdev->dev.of_node;
+	const struct of_device_id *match =
+		of_match_device(of_match_ptr(snd_davinci_audiocard_dt_ids), &pdev->dev);
+	struct snd_soc_dai_link *dai = (struct snd_soc_dai_link *) match->data;
+	struct snd_soc_card_drvdata_davinci *drvdata = NULL;
+	struct clk *mclk;
+	int ret = 0;
+
+	snd_davinci_audiocard.dai_link = dai;
+
+	/*
+		Parse device tree properties and nodes of Bone Cape for AD1938 AudioCard
+	*/
+	dai->codec_of_node = of_parse_phandle(np, "audio-codec", 0);
+	if (!dai->codec_of_node)
+		return -EINVAL;
+
+	dai->cpu_of_node = of_parse_phandle(np, "mcasp-controller", 0);
+	if (!dai->cpu_of_node)
+		return -EINVAL;
+
+	dai->platform_of_node = dai->cpu_of_node;
+
+	snd_davinci_audiocard.dev = &pdev->dev;
+	ret = snd_soc_of_parse_card_name(&snd_davinci_audiocard, "model");
+	if (ret)
+		return ret;
+
+	mclk = devm_clk_get(&pdev->dev, "mclk");
+	if (PTR_ERR(mclk) == -EPROBE_DEFER) {
+		return -EPROBE_DEFER;
+	} else if (IS_ERR(mclk)) {
+		dev_dbg(&pdev->dev, "mclk not found.\n");
+		mclk = NULL;
+	}
+
+	drvdata = devm_kzalloc(&pdev->dev, sizeof(*drvdata), GFP_KERNEL);
+	if (!drvdata)
+		return -ENOMEM;
+
+	drvdata->mclk = mclk;
+
+	ret = of_property_read_u32(np, "codec-clock-rate", &drvdata->codec_clock);
+	if (ret < 0){
+		dev_err(&pdev->dev, "No codec clock rate defined.\n");
+		return -EINVAL;
+	}
+
+	/*
+		Configure internal 24,576 MHz oscillator as master clock for McASP
+	*/
+	ret = of_property_read_u32(np, "cpu-clock-rate", &drvdata->sysclk);
+	if (ret < 0) {
+		if (!drvdata->mclk) {
+			dev_err(&pdev->dev,
+				"No clock or clock rate defined.\n");
+			return -EINVAL;
+		}
+		drvdata->sysclk = clk_get_rate(drvdata->mclk);
+	} else if (drvdata->mclk) {
+		unsigned int requestd_rate = drvdata->sysclk;
+		clk_set_rate(drvdata->mclk, drvdata->sysclk);
+		drvdata->sysclk = clk_get_rate(drvdata->mclk);
+		if (drvdata->sysclk != requestd_rate)
+			dev_warn(&pdev->dev,
+				 "Could not get requested rate %u using %u.\n",
+				 requestd_rate, drvdata->sysclk);
+	}
+
+	/*
+		Register AD1938 AudioCard
+	*/
+	snd_soc_card_set_drvdata(&snd_davinci_audiocard, drvdata);
+	ret = devm_snd_soc_register_card(&pdev->dev, &snd_davinci_audiocard);
+	if (ret)
+		dev_err(&pdev->dev, "snd_soc_register_card failed (%d)\n", ret);
+
+	return ret;
+}
+
+/* Sound card disconnect */
+static int snd_davinci_audiocard_remove(struct platform_device *pdev)
+{
+	return snd_soc_unregister_card(&snd_davinci_audiocard);
+}
+
+/* Sound card platform driver */
+static struct platform_driver snd_davinci_audiocard_driver = {
+	.probe          = snd_davinci_audiocard_probe,
+	.driver = {
+		.name   = "snd_ctag_face_2_4",
+		.pm = &snd_soc_pm_ops,
+		.of_match_table = of_match_ptr(snd_davinci_audiocard_dt_ids),
+	},
+	.remove = snd_davinci_audiocard_remove,
+};
+
+module_platform_driver(snd_davinci_audiocard_driver);
+
+/* Module information */
+MODULE_AUTHOR("Henrik Langer");
+MODULE_DESCRIPTION("ALSA SoC AD193X AudioCard driver");
+MODULE_LICENSE("GPL");

--- a/sound/soc/davinci/davinci-mcasp.c
+++ b/sound/soc/davinci/davinci-mcasp.c
@@ -918,7 +918,7 @@ static int mcasp_i2s_hw_param(struct davinci_mcasp *mcasp, int stream,
 		for (i = 0; i < active_slots; i++)
 			mask |= (1 << i);
 	}
-	mcasp_clr_bits(mcasp, DAVINCI_MCASP_ACLKXCTL_REG, TX_ASYNC);
+	mcasp_set_bits(mcasp, DAVINCI_MCASP_ACLKXCTL_REG, TX_ASYNC);
 
 	if (!mcasp->dat_port)
 		busel = TXSEL;


### PR DESCRIPTION
- Added base device tree for BeagleBone Green to configure McASP
- Added ASoC machine driver for CTAG face2|4 (connects McASP <-> AD1938 audio codec)
- Added support for higher sampling rates in AD1938 codec driver
- Changed initial configuration of AD1938 audio codec
- Modified McASP platform driver to use asynchronous sampling rates in I2S mode (this could be a problem with other soundcards, but is needed for the CTAG face2|4 Audio Card.
- Modified Kconfigs and Makefiles to use CTAG face2|4 Audio Card

The full article about CTAG face2|4 Audio Card is published here:
www.creative-technologies.de/linux-based-low-latency-multichannel-audio-system-2/