### PR TITLE
Bug Fix: add gpio pinctrl-name

### DIFF
--- a/arch/arm/boot/dts/am335x-bone-common-pinmux.dtsi
+++ b/arch/arm/boot/dts/am335x-bone-common-pinmux.dtsi
@@ -1526,7 +1526,7 @@
 	P8_18_pinmux {
 		compatible = "bone-pinmux-helper";
 		status = "okay";
-		pinctrl-names = "default", "gpio";
+		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd";
 		pinctrl-0 = <&P8_18_default_pin>;
 		pinctrl-1 = <&P8_18_gpio_pin>;
 		pinctrl-2 = <&P8_18_gpio_pu_pin>;
@@ -1547,7 +1547,7 @@
 	P8_26_pinmux {
 		compatible = "bone-pinmux-helper";
 		status = "okay";
-		pinctrl-names = "default", "gpio";
+		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd";
 		pinctrl-0 = <&P8_26_default_pin>;
 		pinctrl-1 = <&P8_26_gpio_pin>;
 		pinctrl-2 = <&P8_26_gpio_pu_pin>;


### PR DESCRIPTION
add missing gpio pinctrl-name at arch/arm/boot/dts/am335x-bone-common-pinmux.dtsi (P8_18,P8_26)
