### PR TITLE
update roboticscape device trees for v0.4.0 RC lib

### DIFF
--- a/arch/arm/boot/dts/am335x-boneblack-roboticscape.dts
+++ b/arch/arm/boot/dts/am335x-boneblack-roboticscape.dts
@@ -1,16 +1,18 @@
 /*
- * Copyright (C) 2012 Texas Instruments Incorporated - http://www.ti.com/
+ * @file am335x-boneblack-roboticscape.dtb
  *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License version 2 as
- * published by the Free Software Foundation.
- */
-
- /******************************************************************************
+ * based on am335x-boneblack.dtb
+ *
  * This device tree serves to replace the need for an overlay when using
  * the RoboticsCape. It is similar to the boneblue tree but preserves
  * pin config for the black.
- ******************************************************************************/
+ *
+ * This file was updated in April 2018 to support LED driver like in BB Blue
+ * This goes in sync with V0.4.0 of the Robotics Cape library
+ *
+ * @author James Strawson
+ * @date April 19, 2018
+ */
 
 
 /dts-v1/;
@@ -18,7 +20,6 @@
 #include "am33xx.dtsi"
 #include "am335x-bone-common-no-capemgr.dtsi"
 #include "am335x-bone-common-universal-pins.dtsi"
-/* #include "am33xx-pruss-rproc.dtsi" */
 #include "am335x-roboticscape.dtsi"
 
 / {

--- a/arch/arm/boot/dts/am335x-boneblack-wireless-roboticscape.dts
+++ b/arch/arm/boot/dts/am335x-boneblack-wireless-roboticscape.dts
@@ -1,16 +1,18 @@
 /*
- * Copyright (C) 2012 Texas Instruments Incorporated - http://www.ti.com/
+ * @file am335x-boneblack-wireless-roboticscape.dtb
  *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License version 2 as
- * published by the Free Software Foundation.
- */
-
- /******************************************************************************
+ * based on am335x-boneblack-wireless.dtb
+ *
  * This device tree serves to replace the need for an overlay when using
  * the RoboticsCape. It is similar to the boneblue tree but preserves
  * pin config for the black.
- ******************************************************************************/
+ *
+ * This file was updated in April 2018 to support LED driver like in BB Blue
+ * This goes in sync with V0.4.0 of the Robotics Cape library
+ *
+ * @author James Strawson
+ * @date April 19, 2018
+ */
 
 
 /dts-v1/;
@@ -18,7 +20,6 @@
 #include "am33xx.dtsi"
 #include "am335x-bone-common-no-capemgr.dtsi"
 #include "am335x-bone-common-universal-pins.dtsi"
-/* #include "am33xx-pruss-rproc.dtsi" */
 #include "am335x-boneblack-wl1835.dtsi"
 #include "am335x-roboticscape.dtsi"
 
@@ -45,13 +46,11 @@
 	status = "okay";
 };
 
-&cpu0_opp_table {
-	/*
-	 * All PG 2.0 silicon may not support 1GHz but some of the early
-	 * BeagleBone Blacks have PG 2.0 silicon which is guaranteed
-	 * to support 1GHz OPP so enable it for PG 2.0 on this board.
-	 */
-	oppnitro@1000000000 {
-		opp-supported-hw = <0x06 0x0100>;
-	};
+&mac {
+	status = "disabled";
 };
+
+&mmc3 {
+	status = "okay";
+};
+

--- a/arch/arm/boot/dts/am335x-boneblue.dts
+++ b/arch/arm/boot/dts/am335x-boneblue.dts
@@ -539,3 +539,10 @@
 	pinctrl-0 = <&dcan1_pins>;
 	status = "okay";
 };
+
+&tscadc {
+	status = "okay";
+	adc {
+		ti,adc-channels = <0 1 2 3 4 5 6 7>;
+	};
+};

--- a/arch/arm/boot/dts/am335x-roboticscape.dtsi
+++ b/arch/arm/boot/dts/am335x-roboticscape.dtsi
@@ -1,9 +1,25 @@
-/*******************************************************************************
-* pinmux and modules used by roboticscape
-* included in:
-* am335x-boneblack-roboticscape.dts
-* am335x-boneblack-wireless-roboticscape.dts
-*******************************************************************************/
+/*
+ * @file am335x-roboticscape.dtsi
+ *
+ * used by:
+ * am335x-boneblack-roboticscape.dts
+ * am335x-boneblack-wireless-roboticscape.dts
+ *
+ *
+ * @file am335x-boneblack-roboticscape.dtb
+ *
+ * based on am335x-boneblack.dtb
+ *
+ * This device tree serves to replace the need for an overlay when using the
+ * RoboticsCape. It is similar to the boneblue tree but preserves pin config for
+ * the black.
+ *
+ * This file was updated in April 2018 to support LED driver like in BB Blue
+ * This goes in sync with V0.4.0 of the Robotics Cape library
+ *
+ * @author     James Strawson
+ * @date       April 19, 2018
+ */
 
 
 
@@ -12,9 +28,9 @@
 *******************************************************************************/
 &am33xx_pinmux {
 
-	/***************************************************************************
-	* Static Pinmux
-	***************************************************************************/
+/*******************************************************************************
+* Static Pinmux
+*******************************************************************************/
 	mux_helper_pins: pins {
 		pinctrl-single,pins = <
 
@@ -22,14 +38,6 @@
 			0x09c 0x37	/*P8.9  T6  PAUSE_BTN */
 			0x098 0x37	/*P8.10 U6  MODE_BTN  */
 			0x1AC 0x37	/*P9.25 A14 IMU_INT   */
-
-			/* LEDs GPIO Out*/
-			0x090 0x0F	/* P8.7 R7 LED_RED */
-			0x094 0x0F	/* P8.8 T7 LED_GREEN */
-			0x028 0x0F	/*P8.14 T11 BATT_LED_4 */
-			0x02C 0x0F	/*P8.17 U12 BATT_LED_1 */
-			0x08c 0x0F	/*P8.18 V12 BATT_LED_2 */
-			0x07c 0x0F	/*P8.26 V6  BATT_LED_3 */
 
 			/* Motor Control GPIO Out*/
 			0x0cc 0x0F	/*P8.34 MDIR_2B different from blue!!*/
@@ -41,22 +49,6 @@
 			0x074 0x0F	/*P9.13 MDIR_1B*/
 			0x040 0x0F	/*P9.15 MDIR_2A*/
 			0x1b4 0x0F	/*P9.41 MOT_STBY*/
-
-			/* HRPWM 1 */
-			0x048  0x6 /* P9_14 | MODE 6 */
-			0x04c  0x6 /* P9_16 | MODE 6 */
-
-			/* HRPWM 2 */
-			0x020  0x4 /* P8_19 | MODE 4 */
-			0x024  0x4 /* P8_13 | MODE 4 */
-
-			/* EQEP */
-			0x1A0 0x31  /* P9_42,EQEP0A, MODE1 */
-			0x1A4 0x31  /* P9_27,EQEP0B, MODE1 */
-			0x0D4 0x32  /* P8_33,EQEP1B, MODE2 */
-			0x0D0 0x32  /* P8_35,EQEP1A, MODE2 */
-			0x030 0x34  /* P8_12,EQEP2A, MODE4 */
-			0x034 0x34  /* P8_11,EQEP2B, MODE4 */
 
 			/* PRU encoder input */
 			0x03c 0x36	/* P8_15,PRU0_r31_15,MODE6 */
@@ -85,6 +77,18 @@
 			0x0C4 0x34	/* P8.38,uart5_rxd,MODE4 */
 			0x0C0 0x14	/* P8.37,uart5_txd,MODE4 */
 
+		>;
+	};
+
+
+	led_pins: pinmux_led_pins {
+		pinctrl-single,pins = <
+			0x090 (PIN_OUTPUT | MUX_MODE7) /* (R7) gpmc_advn_ale.gpio2[2] - P8.7, LED_RED, GP1_PIN_5 */
+			0x094 (PIN_OUTPUT | MUX_MODE7) /* (T7) gpmc_oen_ren.gpio2[3] - P8.8, LED_GREEN, GP1_PIN_6 */
+			0x02C (PIN_OUTPUT | MUX_MODE7) /* (U12) gpmc_ad11.gpio0[27] - P8.17, BATT_LED_1 */
+			0x08c (PIN_OUTPUT | MUX_MODE7) /* (V12) gpio2.1 - P8.18  BATT_LED_2 diff from BLUE! */
+			0x07C (PIN_OUTPUT | MUX_MODE7) /* (V6) gpmc_csn0.gpio1[29] - P8.26, BATT_LED_3 */
+			0x028 (PIN_OUTPUT | MUX_MODE7) /* (T11) gpmc_ad10.gpio0[26] - P8.14, BATT_LED_4 */
 		>;
 	};
 
@@ -119,136 +123,136 @@
 
 	/* UART 2 TX GPS*/
 	P9_21_pinmux {
-        compatible = "bone-pinmux-helper";
-        status = "okay";
-        pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "spi", "uart", "i2c", "pwm";
-        pinctrl-0 = <&P9_21_default_pin>;
-        pinctrl-1 = <&P9_21_gpio_pin>;
-        pinctrl-2 = <&P9_21_gpio_pu_pin>;
-        pinctrl-3 = <&P9_21_gpio_pd_pin>;
-        pinctrl-4 = <&P9_21_spi_pin>;
-        pinctrl-5 = <&P9_21_uart_pin>;
-        pinctrl-6 = <&P9_21_i2c_pin>;
-        pinctrl-7 = <&P9_21_pwm_pin>;
-    };
+		compatible = "bone-pinmux-helper";
+		status = "okay";
+		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "spi", "uart", "i2c", "pwm";
+		pinctrl-0 = <&P9_21_default_pin>;
+		pinctrl-1 = <&P9_21_gpio_pin>;
+		pinctrl-2 = <&P9_21_gpio_pu_pin>;
+		pinctrl-3 = <&P9_21_gpio_pd_pin>;
+		pinctrl-4 = <&P9_21_spi_pin>;
+		pinctrl-5 = <&P9_21_uart_pin>;
+		pinctrl-6 = <&P9_21_i2c_pin>;
+		pinctrl-7 = <&P9_21_pwm_pin>;
+	};
 
-    /* UART 2 RX GPS */
-    P9_22_pinmux {
-        compatible = "bone-pinmux-helper";
-        status = "okay";
-        pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "spi", "uart", "i2c", "pwm";
-        pinctrl-0 = <&P9_22_default_pin>;
-        pinctrl-1 = <&P9_22_gpio_pin>;
-        pinctrl-2 = <&P9_22_gpio_pu_pin>;
-        pinctrl-3 = <&P9_22_gpio_pd_pin>;
-        pinctrl-4 = <&P9_22_spi_pin>;
-        pinctrl-5 = <&P9_22_uart_pin>;
-        pinctrl-6 = <&P9_22_i2c_pin>;
-        pinctrl-7 = <&P9_22_pwm_pin>;
-    };
+	/* UART 2 RX GPS */
+	P9_22_pinmux {
+		compatible = "bone-pinmux-helper";
+		status = "okay";
+		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "spi", "uart", "i2c", "pwm";
+		pinctrl-0 = <&P9_22_default_pin>;
+		pinctrl-1 = <&P9_22_gpio_pin>;
+		pinctrl-2 = <&P9_22_gpio_pu_pin>;
+		pinctrl-3 = <&P9_22_gpio_pd_pin>;
+		pinctrl-4 = <&P9_22_spi_pin>;
+		pinctrl-5 = <&P9_22_uart_pin>;
+		pinctrl-6 = <&P9_22_i2c_pin>;
+		pinctrl-7 = <&P9_22_pwm_pin>;
+	};
 
-    /* SPI MISO */
-    P9_29_pinmux {
-        compatible = "bone-pinmux-helper";
-        status = "okay";
-        pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "pwm", "spi", "pruout", "pruin";
-        pinctrl-0 = <&P9_29_default_pin>;
-        pinctrl-1 = <&P9_29_gpio_pin>;
-        pinctrl-2 = <&P9_29_gpio_pu_pin>;
-        pinctrl-3 = <&P9_29_gpio_pd_pin>;
-        pinctrl-4 = <&P9_29_pwm_pin>;
-        pinctrl-5 = <&P9_29_spi_pin>;
-        pinctrl-6 = <&P9_29_pruout_pin>;
-        pinctrl-7 = <&P9_29_pruin_pin>;
-    };
+	/* SPI MISO */
+	P9_29_pinmux {
+		compatible = "bone-pinmux-helper";
+		status = "okay";
+		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "pwm", "spi", "pruout", "pruin";
+		pinctrl-0 = <&P9_29_default_pin>;
+		pinctrl-1 = <&P9_29_gpio_pin>;
+		pinctrl-2 = <&P9_29_gpio_pu_pin>;
+		pinctrl-3 = <&P9_29_gpio_pd_pin>;
+		pinctrl-4 = <&P9_29_pwm_pin>;
+		pinctrl-5 = <&P9_29_spi_pin>;
+		pinctrl-6 = <&P9_29_pruout_pin>;
+		pinctrl-7 = <&P9_29_pruin_pin>;
+	};
 
-    /* SPI MOSI */
-    P9_30_pinmux {
-        compatible = "bone-pinmux-helper";
-        status = "okay";
-        pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "pwm", "spi", "pruout", "pruin";
-        pinctrl-0 = <&P9_30_default_pin>;
-        pinctrl-1 = <&P9_30_gpio_pin>;
-        pinctrl-2 = <&P9_30_gpio_pu_pin>;
-        pinctrl-3 = <&P9_30_gpio_pd_pin>;
-        pinctrl-4 = <&P9_30_pwm_pin>;
-        pinctrl-5 = <&P9_30_spi_pin>;
-        pinctrl-6 = <&P9_30_pruout_pin>;
-        pinctrl-7 = <&P9_30_pruin_pin>;
-    };
+	/* SPI MOSI */
+	P9_30_pinmux {
+		compatible = "bone-pinmux-helper";
+		status = "okay";
+		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "pwm", "spi", "pruout", "pruin";
+		pinctrl-0 = <&P9_30_default_pin>;
+		pinctrl-1 = <&P9_30_gpio_pin>;
+		pinctrl-2 = <&P9_30_gpio_pu_pin>;
+		pinctrl-3 = <&P9_30_gpio_pd_pin>;
+		pinctrl-4 = <&P9_30_pwm_pin>;
+		pinctrl-5 = <&P9_30_spi_pin>;
+		pinctrl-6 = <&P9_30_pruout_pin>;
+		pinctrl-7 = <&P9_30_pruin_pin>;
+	};
 
-    /* SPI SCK */
-    P9_31_pinmux {
-        compatible = "bone-pinmux-helper";
-        status = "okay";
-        pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "pwm", "spi", "pruout", "pruin";
-        pinctrl-0 = <&P9_31_default_pin>;
-        pinctrl-1 = <&P9_31_gpio_pin>;
-        pinctrl-2 = <&P9_31_gpio_pu_pin>;
-        pinctrl-3 = <&P9_31_gpio_pd_pin>;
-        pinctrl-4 = <&P9_31_pwm_pin>;
-        pinctrl-5 = <&P9_31_spi_pin>;
-        pinctrl-6 = <&P9_31_pruout_pin>;
-        pinctrl-7 = <&P9_31_pruin_pin>;
-    };
+	/* SPI SCK */
+	P9_31_pinmux {
+		compatible = "bone-pinmux-helper";
+		status = "okay";
+		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "pwm", "spi", "pruout", "pruin";
+		pinctrl-0 = <&P9_31_default_pin>;
+		pinctrl-1 = <&P9_31_gpio_pin>;
+		pinctrl-2 = <&P9_31_gpio_pu_pin>;
+		pinctrl-3 = <&P9_31_gpio_pd_pin>;
+		pinctrl-4 = <&P9_31_pwm_pin>;
+		pinctrl-5 = <&P9_31_spi_pin>;
+		pinctrl-6 = <&P9_31_pruout_pin>;
+		pinctrl-7 = <&P9_31_pruin_pin>;
+	};
 
-    /* SPI SS1 GPIO3_17*/
+	/* SPI SS1 GPIO3_17*/
 	P9_28_pinmux {
-        compatible = "bone-pinmux-helper";
-        status = "okay";
-        pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "pwm", "spi", "pwm2", "pruout", "pruin";
-        pinctrl-0 = <&P9_28_default_pin>;
-        pinctrl-1 = <&P9_28_gpio_pin>;
-        pinctrl-2 = <&P9_28_gpio_pu_pin>;
-        pinctrl-3 = <&P9_28_gpio_pd_pin>;
-        pinctrl-4 = <&P9_28_pwm_pin>;
-        pinctrl-5 = <&P9_28_spi_pin>;
-        pinctrl-6 = <&P9_28_pwm2_pin>;
-        pinctrl-7 = <&P9_28_pruout_pin>;
-        pinctrl-8 = <&P9_28_pruin_pin>;
-    };
+		compatible = "bone-pinmux-helper";
+		status = "okay";
+		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "pwm", "spi", "pwm2", "pruout", "pruin";
+		pinctrl-0 = <&P9_28_default_pin>;
+		pinctrl-1 = <&P9_28_gpio_pin>;
+		pinctrl-2 = <&P9_28_gpio_pu_pin>;
+		pinctrl-3 = <&P9_28_gpio_pd_pin>;
+		pinctrl-4 = <&P9_28_pwm_pin>;
+		pinctrl-5 = <&P9_28_spi_pin>;
+		pinctrl-6 = <&P9_28_pwm2_pin>;
+		pinctrl-7 = <&P9_28_pruout_pin>;
+		pinctrl-8 = <&P9_28_pruin_pin>;
+	};
 
-    /* SPI SS1  GPIO1_17*/
-    P9_23_pinmux {
-        compatible = "bone-pinmux-helper";
-        status = "okay";
-        pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "pwm";
-        pinctrl-0 = <&P9_23_default_pin>;
-        pinctrl-1 = <&P9_23_gpio_pin>;
-        pinctrl-2 = <&P9_23_gpio_pu_pin>;
-        pinctrl-3 = <&P9_23_gpio_pd_pin>;
-        pinctrl-4 = <&P9_23_pwm_pin>;
-    };
+	/* SPI SS1  GPIO1_17*/
+	P9_23_pinmux {
+		compatible = "bone-pinmux-helper";
+		status = "okay";
+		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "pwm";
+		pinctrl-0 = <&P9_23_default_pin>;
+		pinctrl-1 = <&P9_23_gpio_pin>;
+		pinctrl-2 = <&P9_23_gpio_pu_pin>;
+		pinctrl-3 = <&P9_23_gpio_pd_pin>;
+		pinctrl-4 = <&P9_23_pwm_pin>;
+	};
 
-    /* UART 1 TX */
-     P9_24_pinmux {
-        compatible = "bone-pinmux-helper";
-        status = "okay";
-        pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "uart", "can", "i2c",  "pruin";
-        pinctrl-0 = <&P9_24_default_pin>;
-        pinctrl-1 = <&P9_24_gpio_pin>;
-        pinctrl-2 = <&P9_24_gpio_pu_pin>;
-        pinctrl-3 = <&P9_24_gpio_pd_pin>;
-        pinctrl-4 = <&P9_24_uart_pin>;
-        pinctrl-5 = <&P9_24_can_pin>;
-        pinctrl-6 = <&P9_24_i2c_pin>;
-        pinctrl-7 = <&P9_24_pruin_pin>;
-    };
+	/* UART 1 TX */
+	 P9_24_pinmux {
+		compatible = "bone-pinmux-helper";
+		status = "okay";
+		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "uart", "can", "i2c",  "pruin";
+		pinctrl-0 = <&P9_24_default_pin>;
+		pinctrl-1 = <&P9_24_gpio_pin>;
+		pinctrl-2 = <&P9_24_gpio_pu_pin>;
+		pinctrl-3 = <&P9_24_gpio_pd_pin>;
+		pinctrl-4 = <&P9_24_uart_pin>;
+		pinctrl-5 = <&P9_24_can_pin>;
+		pinctrl-6 = <&P9_24_i2c_pin>;
+		pinctrl-7 = <&P9_24_pruin_pin>;
+	};
 
-    /* UART 1 RX */
-    P9_26_pinmux {
-        compatible = "bone-pinmux-helper";
-        status = "okay";
-        pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "uart", "can", "i2c",  "pruin";
-        pinctrl-0 = <&P9_26_default_pin>;
-        pinctrl-1 = <&P9_26_gpio_pin>;
-        pinctrl-2 = <&P9_26_gpio_pu_pin>;
-        pinctrl-3 = <&P9_26_gpio_pd_pin>;
-        pinctrl-4 = <&P9_26_uart_pin>;
-        pinctrl-5 = <&P9_26_can_pin>;
-        pinctrl-6 = <&P9_26_i2c_pin>;
-        pinctrl-7 = <&P9_26_pruin_pin>;
-    };
+	/* UART 1 RX */
+	P9_26_pinmux {
+		compatible = "bone-pinmux-helper";
+		status = "okay";
+		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "uart", "can", "i2c",  "pruin";
+		pinctrl-0 = <&P9_26_default_pin>;
+		pinctrl-1 = <&P9_26_gpio_pin>;
+		pinctrl-2 = <&P9_26_gpio_pu_pin>;
+		pinctrl-3 = <&P9_26_gpio_pd_pin>;
+		pinctrl-4 = <&P9_26_uart_pin>;
+		pinctrl-5 = <&P9_26_can_pin>;
+		pinctrl-6 = <&P9_26_i2c_pin>;
+		pinctrl-7 = <&P9_26_pruin_pin>;
+	};
 
 
 };
@@ -274,10 +278,14 @@
 };
 
 &ehrpwm1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&P8_19_pwm_pin &P8_13_pwm_pin>;
 	status = "okay";
 };
 
 &ehrpwm2 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&P9_14_pwm_pin &P9_16_pwm_pin>;
 	status = "okay";
 };
 
@@ -285,35 +293,41 @@
 * EQEP
 *******************************************************************************/
 &eqep0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&P9_92_qep_pin &P9_27_qep_pin>;
+
 	count_mode = <0>;  /* 0 - Quadrature mode, normal 90 phase offset cha & chb.  1 - Direction mode.  cha input = clock, chb input = direction */
 	swap_inputs = <0>; /* Are channel A and channel B swapped? (0 - no, 1 - yes) */
 	invert_qa = <1>;   /* Should we invert the channel A input?  */
 	invert_qb = <1>;   /* Should we invert the channel B input? I invert these because my encoder outputs drive transistors that pull down the pins */
 	invert_qi = <0>;   /* Should we invert the index input? */
 	invert_qs = <0>;   /* Should we invert the strobe input? */
-
 	status = "okay";
 };
 
 &eqep1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&P8_33_qep_pin &P8_35_qep_pin>;
+
 	count_mode = <0>;  /* 0 - Quadrature mode, normal 90 phase offset cha & chb.  1 - Direction mode.  cha input = clock, chb input = direction */
 	swap_inputs = <0>; /* Are channel A and channel B swapped? (0 - no, 1 - yes) */
 	invert_qa = <1>;   /* Should we invert the channel A input?  */
 	invert_qb = <1>;   /* Should we invert the channel B input? I invert these because my encoder outputs drive transistors that pull down the pins */
 	invert_qi = <0>;   /* Should we invert the index input? */
 	invert_qs = <0>;   /* Should we invert the strobe input? */
-
 	status = "okay";
 };
 
 &eqep2 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&P8_12_qep_pin &P8_11_qep_pin>;
+
 	count_mode = <0>;  /* 0 - Quadrature mode, normal 90 phase offset cha & chb.  1 - Direction mode.  cha input = clock, chb input = direction */
 	swap_inputs = <0>; /* Are channel A and channel B swapped? (0 - no, 1 - yes) */
 	invert_qa = <1>;   /* Should we invert the channel A input?  */
 	invert_qb = <1>;   /* Should we invert the channel B input? I invert these because my encoder outputs drive transistors that pull down the pins */
 	invert_qi = <0>;   /* Should we invert the index input? */
 	invert_qs = <0>;   /* Should we invert the strobe input? */
-
 	status = "okay";
 };
 
@@ -391,5 +405,63 @@
 
 		reg = <1>;
 		spi-max-frequency = <16000000>;
+	};
+};
+
+/*******************************************************************************
+* LEDs
+*******************************************************************************/
+/ {
+	leds {
+		pinctrl-names = "default";
+		pinctrl-0 = <&led_pins>;
+		compatible = "gpio-leds";
+
+		red_led {
+			label = "red";
+			gpios = <&gpio2 2 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+
+		green_led {
+			label = "green";
+			gpios = <&gpio2 3 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+
+		batt_1_led {
+			label = "bat25";
+			gpios = <&gpio0 27 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+
+		batt_2_led {
+			label = "bat50";
+			gpios = <&gpio2 1 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+
+		batt_3_led {
+			label = "bat75";
+			gpios = <&gpio1 29 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+
+		batt_4_led {
+			label = "bat100";
+			gpios = <&gpio0 26 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+	};
+
+};
+
+&tscadc {
+	status = "okay";
+	adc {
+		ti,adc-channels = <0 1 2 3 4 5 6 7>;
+		ti,chan-step-avg = <0x16 0x16 0x16 0x16 0x16 0x16 0x16 0x16>;
+		ti,chan-step-opendelay = <0x98 0x98 0x98 0x98 0x98 0x98 0x98 0x98>;
+		ti,chan-step-sampledelay = <0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0>;
 	};
 };


### PR DESCRIPTION
add in IIO adc driver and LED driver in e53189320eaa9df1eeb33df1fa9806dee432a2f2
put adc iio driver from v4.14 back into v4.9 Blue dtb 657b181ef0069b0289647878b967f5238b1afb00