### PR TITLE
net: ieee8021541: bcfserial: Increase the number of retries for hdlc

### DIFF
--- a/drivers/net/ieee802154/bcfserial.c
+++ b/drivers/net/ieee802154/bcfserial.c
@@ -232,7 +232,7 @@ static void bcfserial_hdlc_send_ack(struct bcfserial *bcfserial, u8 address, u8 
 
 static int bcfserial_hdlc_receive(struct bcfserial *bcfserial, u8 cmd, void *buffer, size_t count)
 {
-	int retries = 5;
+	int retries = 80;
 	bcfserial->response_size = count;
 	bcfserial->response_buffer = (u8*)buffer;
 	bcfserial_hdlc_send_cmd(bcfserial, cmd);


### PR DESCRIPTION
During initialization the CC1352 FW will be in a loop looking for HDLC ACK and FW response is very slow, but currently bcfserial driver expects the CC1352 to respond within 50 ms, but the CC1352 takes few 100 ms to complete this operation, thus keep the retry count to a high value so that the probe failure does not happen due to failling the bcfserial_get_device_capabilities() call.This is a one-time setup delay during probe() and does not affect performance.

Signed-off-by: Vaishnav Achath <vaishnav.a@ti.com>