### PR TITLE
Fix play m4f

### DIFF
--- a/arch/arm64/boot/dts/ti/k3-am625-beagleplay.dts
+++ b/arch/arm64/boot/dts/ti/k3-am625-beagleplay.dts
@@ -77,19 +77,19 @@
 
 		mcu_m4fss_memory_region: m4f-memory@9cc00000 {
 			compatible = "shared-dma-pool";
-			reg = <0x00 0x9cc00000 0x00 0xd00000>;
+			reg = <0x00 0x9cc00000 0x00 0xe00000>;
 			no-map;
 		};
 
-		wkup_r5fss0_core0_dma_memory_region: r5f-dma-memory@9d900000 {
+		wkup_r5fss0_core0_dma_memory_region: r5f-dma-memory@9da00000 {
 			compatible = "shared-dma-pool";
-			reg = <0x00 0x9d900000 0x00 0x00100000>;
+			reg = <0x00 0x9da00000 0x00 0x00100000>;
 			no-map;
 		};
 
-		wkup_r5fss0_core0_memory_region: r5f-memory@9da00000 {
+		wkup_r5fss0_core0_memory_region: r5f-memory@9db00000 {
 			compatible = "shared-dma-pool";
-			reg = <0x00 0x9da00000 0x00 0x00d00000>;
+			reg = <0x00 0x9db00000 0x00 0x00c00000>;
 			no-map;
 		};
 

--- a/arch/arm64/boot/dts/ti/k3-am625-beagleplay.dts
+++ b/arch/arm64/boot/dts/ti/k3-am625-beagleplay.dts
@@ -781,6 +781,11 @@
 	};
 };
 
+&mcu_rti0 {
+      /* Tightly coupled to M4F */
+      status = "disabled";
+};
+
 &mcu_m4fss {
 	status = "disabled";
 };

--- a/arch/arm64/boot/dts/ti/k3-am625-beagleplay.dts
+++ b/arch/arm64/boot/dts/ti/k3-am625-beagleplay.dts
@@ -787,7 +787,9 @@
 };
 
 &mcu_m4fss {
-	status = "disabled";
+	mboxes = <&mailbox0_cluster0 &mbox_m4_0>;
+	memory-region = <&mcu_m4fss_dma_memory_region>,
+			<&mcu_m4fss_memory_region>;
 };
 
 &fss {


### PR DESCRIPTION
Fixup the RTI which was creating problems for M4F startup - M4F is tightly coupled to the processor itself, and the intent was for M4F to manage the RTI watchdog and usage by A53 is not practical.