### PR TITLE
ARM: dts: ti/omap: fix incorrect compatible string in internal eeprom node

### DIFF
--- a/arch/arm/boot/dts/ti/omap/am335x-bone-common.dtsi
+++ b/arch/arm/boot/dts/ti/omap/am335x-bone-common.dtsi
@@ -217,7 +217,7 @@
 	};
 
 	baseboard_eeprom: eeprom@50 {
-		compatible = "atmel,24c256";
+		compatible = "atmel,24c32";
 		reg = <0x50>;
 		vcc-supply = <&ldo4_reg>;
 


### PR DESCRIPTION
While the Beaglebone capes have the Atmel AT24C256 chip (256kbit or 32kB), the internal Beaglebone eeprom chip (i2c bus 0, addr 0x50), is an AT24C32 (32kbit or 4kB).

You can confirm this by running `sudo hexdump -C /sys/bus/nvmem/devices/0-00500/nvmem`. You can see the factory data is repeated every 0x1000 addresses (every 4096 bytes or 32768 bits). This is because the read command wraps around to reading 0x0000 when a user requests address 0x1000

This is not a huge issue for reading, but it is for writing to the EEPROM for two reasons:
1) If a user writes to addresses 0x1000 - 0x104e, they'll accidentally overwrite the factory data stored at 0x0000 - 0x104e. This also is an issue for writing to 0x2000 - 0x204e, and so on
2) AT24C256 has 64-byte pages, but AT24C32 only has 32 byte pages. Thus, if you attempt to write more than 32 bytes, bytes 32-64 will wrap around. This causes your data in the actual EEPROM chip's bytes 0-32 to be overwritten by the data in your request's bytes 32-64, while the EEPROM chip's bytes 32-64 remain 0xFF (unwritten).

Lastly, the Beaglebone Black's user manual does correctly mention that the internal EEPROM is 4kB (while capes are 32kB or 256kbit). It's just this bit of code that does not match.